### PR TITLE
fix: Stop policy eval when context is done

### DIFF
--- a/act/policy_test.go
+++ b/act/policy_test.go
@@ -1,0 +1,53 @@
+package act
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestPolicy_Eval(t *testing.T) {
+	t.Run("it should eval program correctly", func(t *testing.T) {
+		policy := MustNewPolicy("test", "1 + 1", map[string]any{})
+		resp, err := policy.Eval(context.Background(), Input{})
+		require.NoError(t, err)
+		assert.Equal(t, 2, resp)
+	})
+
+	t.Run("it should stop eval if context is timed out", func(t *testing.T) {
+		policy := MustNewPolicy("test", "repeat(\"Hi\", 100000)", map[string]any{})
+		ctx, cancel := context.WithTimeout(context.Background(), 10)
+		defer cancel()
+		_, err := policy.Eval(ctx, Input{})
+		require.Error(t, err)
+	})
+
+	t.Run("it should fail because of runtime error", func(t *testing.T) {
+		policy := MustNewPolicy("test", `nonExistantVariable`, map[string]any{})
+		_, err := policy.Eval(context.Background(), Input{
+			Policy: map[string]any{"key": "value"},
+		})
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+}
+
+func TestPolicy_MustCompile(t *testing.T) {
+	t.Run("it should compile policy correctly", func(t *testing.T) {
+		policy := Policy{
+			Name:     "test",
+			Policy:   "1 + 1",
+			Metadata: map[string]any{"log": "enabled"},
+		}
+		require.NoError(t, policy.MustCompile())
+	})
+
+	t.Run("it should fail to compile policy if there is an error", func(t *testing.T) {
+		policy := Policy{
+			Name:     "test",
+			Policy:   "1 + \"Hi\"",
+			Metadata: map[string]any{"log": "enabled"},
+		}
+		require.Error(t, policy.MustCompile())
+	})
+}


### PR DESCRIPTION
# Ticket(s)

While working on Act timeout, I realized that the context used to control timeout for policy evaluation is not actually used in the eval function. Unless I was missing something, this PR should fix that and use the context to actually stop the policy evaluation when the context is canceled or timed out

## Description

## Related PRs

## Development Checklist

- [x] I have added a descriptive title to this PR.
- [x] I have squashed related commits together.
- [x] I have rebased my branch on top of the latest main branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added docstring(s) and type annotations to my code.
- [ ] I have made corresponding changes to the documentation (docs).
- [x] I have added tests for my changes.

## Legal Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/gatewayd-io/gatewayd/blob/main/CONTRIBUTING.md) document.
- [x] I have read and understood the [Code of Conduct](https://github.com/gatewayd-io/gatewayd/blob/main/CODE_OF_CONDUCT.md).
- [x] I have read and agreed to the [Apache CLA](https://www.apache.org/licenses/contributor-agreements.html) (required).
- [x] I have read and agreed to the [LICENSE](https://github.com/gatewayd-io/gatewayd/blob/main/LICENSE) (required).
